### PR TITLE
Attach Loose References

### DIFF
--- a/cyfhir/src/main/java/com/Optum/CyFHIR/procedures/Bundle.java
+++ b/cyfhir/src/main/java/com/Optum/CyFHIR/procedures/Bundle.java
@@ -11,8 +11,8 @@ import java.util.*;
 import java.util.stream.Stream;
 
 public class Bundle {
-
     public static Validator validator;
+
     @Context
     public GraphDatabaseService db;
 

--- a/cyfhir/src/main/java/com/Optum/CyFHIR/procedures/Resource.java
+++ b/cyfhir/src/main/java/com/Optum/CyFHIR/procedures/Resource.java
@@ -20,6 +20,7 @@ import org.neo4j.procedure.*;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class Resource {
@@ -44,24 +45,36 @@ public class Resource {
         Map<String, Object> resourceMap = stringToMap(json);
         // Validate
         String resourceType = (String) resourceMap.get("resourceType");
-        this.validateFHIR(json, resourceType, configMap);
+        validateFHIR(json, resourceType, configMap);
 
         Entry entry = new Entry();
         entry.setResource(resourceMap);
         // Relationship Array
         ArrayList<FhirRelationship> relationships = addToDatabase(entry, tx);
         createRelationships(relationships, tx);
-        // Create paths list
-        List<Path> response = new ArrayList<Path>();
-        // Create map for config
-        Map<String, Object> responseMap = new HashMap<String, Object>();
-        // Return apoc method results
-        Convert convert = new Convert();
-        Stream<MapResult> stream = convert.toTree(response, true, responseMap);
+        // Array for FullUrl
+        ArrayList<String> fullUrls = new ArrayList<>();
+        fullUrls.add((String) entry.get("fullUrl"));
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("fullUrls", fullUrls);
+        Stream<MapResult> stream = Stream.of(new MapResult(responseMap));
+
+        // This function attaches references to a resource being loaded from previously loaded resources.
+        // It runs a Cypher Query due to there being >700 possible node labels that can have a reference as a property
+        attachLooseReferences(fullUrls, tx);
 
         tx.commit();
         tx.close();
         return stream;
+    }
+
+    public void attachLooseReferences(ArrayList<String> fullUrls, Transaction tx) {
+        String collect = fullUrls.stream().collect(Collectors.joining("\", \"", "[\"", "\"]"));
+        String cypher = "MATCH (a)\n" + "MATCH (b:entry {fullUrl: a.reference}) \n" + "WHERE NOT (a)-[:reference]->()\n"
+                + "AND b.fullUrl IN " + collect + " \n CREATE (a)-[:reference]->(b)";
+
+        tx.execute(cypher);
     }
 
     public IAnyResource validateFHIR(String json, String resourceType, Map<String, Object> configMap) throws Exception {
@@ -85,8 +98,7 @@ public class Resource {
         ResourceIterator<Node> nodes = tx.findNodes(Label.label(resourceType), "fullUrl", entry.get("fullUrl"));
         ArrayList<FhirRelationship> rels = new ArrayList<>();
         try {
-            Node duplicate = nodes.next();
-            System.out.println("Duplicate Node: " + duplicate.toString());
+            System.out.println("Duplicate Resource With ID: " + nodes.next().getProperty("_resourceId").toString());
         } catch (Exception e) {
             // Get resource ID
             Map<String, Object> resourceMap = (Map<String, Object>) entry.get("resource");
@@ -109,9 +121,8 @@ public class Resource {
         relationships.forEach((o) -> {
             Label label = Label.label("entry");
             String childID = o.getChildUUID();
-            String childURN = "urn:uuid:" + childID;
             // Retrieve child node
-            Node childNode = tx.findNode(label, "fullUrl", childURN);
+            Node childNode = tx.findNode(label, "fullUrl", childID);
             // Get parent node
             Node parentNode = o.getParentNode();
             // Get relationship string
@@ -202,7 +213,7 @@ public class Resource {
         // Create relationship if we have a reference
         if (json.containsKey("reference")) {
             // Get child node reference
-            String referenceID = json.get("reference").toString().substring(9);
+            String referenceID = json.get("reference").toString();
             // Create relationship object
             FhirRelationship ref = new FhirRelationship();
             // Set parent id

--- a/cyfhir/src/main/java/com/Optum/CyFHIR/procedures/Resource.java
+++ b/cyfhir/src/main/java/com/Optum/CyFHIR/procedures/Resource.java
@@ -26,8 +26,8 @@ import java.util.stream.Stream;
 public class Resource {
     public static final Uniqueness UNIQUENESS = Uniqueness.RELATIONSHIP_PATH;
     public static final boolean BFS = true;
-
     public static Validator validator;
+
     @Context
     public GraphDatabaseService db;
 
@@ -73,7 +73,6 @@ public class Resource {
         String collect = fullUrls.stream().collect(Collectors.joining("\", \"", "[\"", "\"]"));
         String cypher = "MATCH (a)\n" + "MATCH (b:entry {fullUrl: a.reference}) \n" + "WHERE NOT (a)-[:reference]->()\n"
                 + "AND b.fullUrl IN " + collect + " \n CREATE (a)-[:reference]->(b)";
-
         tx.execute(cypher);
     }
 

--- a/cyfhir/src/main/java/com/Optum/CyFHIR/procedures/Resource.java
+++ b/cyfhir/src/main/java/com/Optum/CyFHIR/procedures/Resource.java
@@ -70,9 +70,9 @@ public class Resource {
     }
 
     public void attachLooseReferences(ArrayList<String> fullUrls, Transaction tx) {
-        String collect = fullUrls.stream().collect(Collectors.joining("\", \"", "[\"", "\"]"));
-        String cypher = "MATCH (a)\n" + "MATCH (b:entry {fullUrl: a.reference}) \n" + "WHERE NOT (a)-[:reference]->()\n"
-                + "AND b.fullUrl IN " + collect + " \n CREATE (a)-[:reference]->(b)";
+        String prefix = "MATCH (a) MATCH (b:entry {fullUrl: a.reference}) WHERE NOT (a)-[:reference]->() AND b.fullUrl IN [\"";
+        String suffix = "\"] CREATE (a)-[:reference]->(b)";
+        String cypher = fullUrls.stream().collect(Collectors.joining("\", \"", prefix, suffix));
         tx.execute(cypher);
     }
 

--- a/cyfhir/src/test/java/com/Optum/CyFHIR/models/ValidatorTest.java
+++ b/cyfhir/src/test/java/com/Optum/CyFHIR/models/ValidatorTest.java
@@ -6,7 +6,6 @@ import com.Optum.CyFHIR.procedures.Resource;
 import org.hl7.fhir.instance.model.api.IAnyResource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
-import org.neo4j.procedure.Name;
 import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/cyfhir/src/test/java/com/Optum/CyFHIR/procedures/ResourceTest.java
+++ b/cyfhir/src/test/java/com/Optum/CyFHIR/procedures/ResourceTest.java
@@ -2,7 +2,6 @@ package com.Optum.CyFHIR.procedures;
 
 // Don't Optimize org.neo4j.driver imports, prevents type ambiguity
 
-import org.junit.Assert;
 import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
@@ -20,8 +19,6 @@ import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/cyfhir/src/test/java/com/Optum/CyFHIR/procedures/ResourceTest.java
+++ b/cyfhir/src/test/java/com/Optum/CyFHIR/procedures/ResourceTest.java
@@ -2,6 +2,7 @@ package com.Optum.CyFHIR.procedures;
 
 // Don't Optimize org.neo4j.driver imports, prevents type ambiguity
 
+import org.junit.Assert;
 import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
@@ -88,6 +89,58 @@ class ResourceTest {
                 assertThat(resultNode.get("id")).isNotNull();
                 assertThat(resultNode.get("id").toString()).isEqualTo(id);
             }
+        }
+    }
+
+    @Test
+    void testLoadSequence() throws IOException {
+        Map patient = loadJsonFromFile("src/test/resources/Patient.json");
+        String patientString = toJsonString(patient);
+
+        Map encounter = loadJsonFromFile("src/test/resources/Encounter.json");
+        String encounterString = toJsonString(encounter);
+
+        Map condition = loadJsonFromFile("src/test/resources/Condition.json");
+        String conditionString = toJsonString(condition);
+
+        Driver driver = getSessionDriver();
+        try (Session session = driver.session()) {
+            // Run in order that automatically links references due to nature of the order
+            session.run("CALL cyfhir.resource.load(" + patientString + ")");
+            session.run("CALL cyfhir.resource.load(" + encounterString + ")");
+            session.run("CALL cyfhir.resource.load(" + conditionString + ")");
+
+            String metricQuery = "MATCH (n) \n" + " WITH COUNT(n) as node_count\n" + " MATCH ()-[r]->()\n"
+                    + " WITH node_count, COUNT(r) as relationship_count\n" + " RETURN node_count, relationship_count";
+
+            Result result1 = session.run(metricQuery);
+
+            List<Record> records1 = result1.stream().collect(Collectors.toList());
+            Record record1 = records1.get(0);
+            Integer node_count1 = record1.get("node_count").asInt();
+            Integer relationship_count1 = record1.get("relationship_count").asInt();
+
+            // Clean up from first part of the test
+            session.run("MATCH (n) DETACH DELETE n");
+
+            // Run in order that normally wouldn't link references due to reverse order, but now should
+            session.run("CALL cyfhir.resource.load(" + conditionString + ")");
+            session.run("CALL cyfhir.resource.load(" + encounterString + ")");
+            session.run("CALL cyfhir.resource.load(" + patientString + ")");
+
+            String metricQuery2 = "MATCH (n) \n" + " WITH COUNT(n) as node_count\n" + " MATCH ()-[r]->()\n"
+                    + " WITH node_count, COUNT(r) as relationship_count\n" + " RETURN node_count, relationship_count";
+
+            Result result2 = session.run(metricQuery);
+
+            List<Record> records2 = result2.stream().collect(Collectors.toList());
+            Record record2 = records2.get(0);
+            Integer node_count2 = record2.get("node_count").asInt();
+            Integer relationship_count2 = record2.get("relationship_count").asInt();
+
+            assertThat(node_count1).isEqualTo(relationship_count1);
+            assertThat(node_count1).isEqualTo(node_count2);
+            assertThat(relationship_count1).isEqualTo(relationship_count2);
         }
     }
 }

--- a/cyfhir/src/test/resources/Condition.json
+++ b/cyfhir/src/test/resources/Condition.json
@@ -1,0 +1,38 @@
+{
+  "resourceType": "Condition",
+  "id": "a4e96085-e006-4f9a-8eb9-00bc41b0ab15",
+  "clinicalStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+        "code": "active"
+      }
+    ]
+  },
+  "verificationStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+        "code": "confirmed"
+      }
+    ]
+  },
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "239873007",
+        "display": "Osteoarthritis of knee"
+      }
+    ],
+    "text": "Osteoarthritis of knee"
+  },
+  "subject": {
+    "reference": "urn:uuid:6aff2910-82fc-44d6-84a6-c29e4b756b11"
+  },
+  "encounter": {
+    "reference": "urn:uuid:6ed0d1c0-f189-42a3-b0bc-deb2a8ac72e8"
+  },
+  "onsetDateTime": "2001-08-31T13:26:41-04:00",
+  "recordedDate": "2001-08-31T13:26:41-04:00"
+}

--- a/cyfhir/src/test/resources/Encounter.json
+++ b/cyfhir/src/test/resources/Encounter.json
@@ -1,0 +1,68 @@
+{
+  "resourceType": "Encounter",
+  "id": "6ed0d1c0-f189-42a3-b0bc-deb2a8ac72e8",
+  "status": "finished",
+  "class": {
+    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "code": "AMB"
+  },
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "185347001",
+          "display": "Encounter for problem"
+        }
+      ],
+      "text": "Encounter for problem"
+    }
+  ],
+  "subject": {
+    "reference": "urn:uuid:6aff2910-82fc-44d6-84a6-c29e4b756b11",
+    "display": "Mrs. Theola421 Haag279"
+  },
+  "participant": [
+    {
+      "type": [
+        {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+              "code": "PPRF",
+              "display": "primary performer"
+            }
+          ],
+          "text": "primary performer"
+        }
+      ],
+      "period": {
+        "start": "2001-08-31T13:26:41-04:00",
+        "end": "2001-08-31T13:41:41-04:00"
+      },
+      "individual": {
+        "reference": "urn:uuid:e47ccc52-d9b7-3589-b220-d0f9b38048d0",
+        "display": "Dr. Latricia419 Spencer878"
+      }
+    }
+  ],
+  "period": {
+    "start": "2001-08-31T13:26:41-04:00",
+    "end": "2001-08-31T13:41:41-04:00"
+  },
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "239873007",
+          "display": "Osteoarthritis of knee"
+        }
+      ]
+    }
+  ],
+  "serviceProvider": {
+    "reference": "urn:uuid:2864a135-87f9-316b-a6b7-a272636846b6",
+    "display": "HIGH POINT REGIONAL HOSPITAL"
+  }
+}

--- a/cyfhir/src/test/resources/Patient.json
+++ b/cyfhir/src/test/resources/Patient.json
@@ -1,9 +1,6 @@
 {
   "resourceType": "Patient",
   "id": "6aff2910-82fc-44d6-84a6-c29e4b756b11",
-  "text": {
-    "status": "generated"
-  },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName",

--- a/cyfhir/src/test/resources/R5Bundle.json
+++ b/cyfhir/src/test/resources/R5Bundle.json
@@ -236,14 +236,14 @@
         "reason": [
           {
             "concept": {
-                "coding": [
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "239873007",
-                      "display": "Osteoarthritis of knee"
-                    }
-                  ]
-              }
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "239873007",
+                  "display": "Osteoarthritis of knee"
+                }
+              ]
+            }
           }
         ],
         "serviceProvider": {


### PR DESCRIPTION
# Description
Found a "bug" where the order of resources being added to Neo4j mattered. If nodes were added that referenced a resource, and that resource wasn't in the database then they would never be linked. This solves that. If a resources is added, it finds all the nodes that SHOULD BE pointing to it as a "reference" and creates that relationship

## Related US/Task
N/A

## Motivation and Context
Order shouldn't matter for loading resources, if it could theoretically create a DB of resources that aren't linked at all! 

## How Has This Been Tested
Wrote test cases and did my own testing using the Demo code, it does slightly impact performance but only by about 1.5%

## Types of changes
<!--- What changes are introduced? Un-comment all that apply: -->
- [ ] Refactoring / dependency upgrade / docs change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional requirement

## Visual screenshots
#### Before:
![graph_before](https://user-images.githubusercontent.com/23388449/93690614-fd9eac80-fa9f-11ea-833d-59456181a981.png)

#### Now:
![graph_after](https://user-images.githubusercontent.com/23388449/93690618-0e4f2280-faa0-11ea-86ec-9b86352cded2.png)
